### PR TITLE
Fix macOS key press beep by not forwarding key events

### DIFF
--- a/thirteen.h
+++ b/thirteen.h
@@ -769,7 +769,10 @@ namespace Thirteen
                         mouseY = (int)(height - p.y);
                     }
 
-                    ((void(*)(id, SEL, id))objc_msgSend)(app, Sel("sendEvent:"), event);
+                    // Forward non-keyboard events to AppKit; forwarding key events can trigger
+                    // the default macOS alert beep when no responder handles keyDown:.
+                    if (eventType != NSEventTypeKeyDown && eventType != NSEventTypeKeyUp)
+                        ((void(*)(id, SEL, id))objc_msgSend)(app, Sel("sendEvent:"), event);
                 }
 
                 if (window)


### PR DESCRIPTION
### Summary
Fixes the macOS system beep that occurs on key press by avoiding forwarding `NSEventTypeKeyDown`/`NSEventTypeKeyUp` events to `NSApplication sendEvent:` after Thirteen already processes those events.

### Problem
On macOS, pressing a key produced a system beep even though input was correctly received.  
Root cause: keyboard events were manually handled and then forwarded to AppKit, which can trigger the default alert beep when no responder handles `keyDown:`.

### Change
In `thirteen.h`, inside the macOS `PumpMessages()` loop:
- Keep existing manual key state updates for key down/up.
- Only call `sendEvent:` for non-keyboard events.

### Why this works
Thirteen remains the owner of keyboard state updates, while AppKit still receives mouse and other events.  
By not forwarding key events, we avoid the unhandled `keyDown:` path that triggers the beep.

### Validation
- Repro before: run sample on macOS, press key -> system beep.
- After change: key input still updates internal state, no system beep.
